### PR TITLE
改了两个地方

### DIFF
--- a/script/Core/GameData.py
+++ b/script/Core/GameData.py
@@ -44,6 +44,7 @@ mapData = {}
 def loadDirNow(dataPath):
     nowData = {}
     if os.listdir(dataPath):
+    # 上面这行可以删掉？
         for i in os.listdir(dataPath):
             nowPath = os.path.join(dataPath,i)
             if os.path.isfile(nowPath):
@@ -62,21 +63,24 @@ def loadDirNow(dataPath):
                         elif nowFile[0] == 'Map':
                             nowMapData = {}
                             mapSystemPath = getMapSystemPathForPath(nowPath)
+                            nowMapData['MapPath'] = mapSystemPath
+                            with open(os.path.join(dataPath,"Map"), 'r') as nowReadFile:
+                                nowMapData['MapDraw'] = nowReadFile.read()
                             mapSystemPathStr = getMapSystemPathStr(mapSystemPath)
                             nowMapData.update(_loadjson(nowPath))
-                            nowMapData = {mapSystemPathStr:nowMapData}
-                            mapData.update(nowMapData)
+                            mapData[mapSystemPathStr] = nowMapData
                         else:
                             nowData[nowFile[0]] = _loadjson(nowPath)
                 elif nowFile[0] == 'Map':
-                    nowReadFile = open(nowPath,'r')
-                    nowMapData = {}
-                    nowMapData['MapDraw'] = nowReadFile.read()
-                    nowReadFile.close()
-                    nowMapSystemPath = getMapSystemPathForPath(nowPath)
-                    nowMapData['MapPath'] = nowMapSystemPath
-                    nowMapSystemPathStr = getMapSystemPathStr(nowMapSystemPath)
-                    mapData[nowMapSystemPathStr].update(nowMapData)
+                    pass # 同Map.json一起处理
+                    # nowReadFile = open(nowPath,'r')
+                    # nowMapData = {}
+                    # nowMapData['MapDraw'] = nowReadFile.read()
+                    # nowReadFile.close()
+                    # nowMapSystemPath = getMapSystemPathForPath(nowPath)
+                    # nowMapData['MapPath'] = nowMapSystemPath
+                    # nowMapSystemPathStr = getMapSystemPathStr(nowMapSystemPath)
+                    # mapData[nowMapSystemPathStr].update(nowMapData)
             else:
                 nowData[i] = loadDirNow(nowPath)
     return nowData
@@ -87,13 +91,13 @@ def getMapSystemPathForPath(nowPath):
     currentDirStr = str(currentDir)
     mapStartList = currentDirStr.split('map')
     currentDirStr = mapStartList[1]
-    mapSystemPath = currentDirStr.split('/')
+    mapSystemPath = currentDirStr.split(os.sep)
     mapSystemPath = mapSystemPath[1:]
     return mapSystemPath
 
 # 获取地图系统路径字符串
 def getMapSystemPathStr(nowPath):
-    return '/'.join(nowPath)
+    return os.sep.join(nowPath)
 
 # 获取路径下所有子路径列表
 def getPathList(pathData):

--- a/script/Design/MapHandle.py
+++ b/script/Design/MapHandle.py
@@ -96,7 +96,7 @@ def characterMoveScene(oldScenePath,newScenePath,characterId):
 
 def getMapSystemPathStrForList(nowList):
     if isinstance(nowList,list):
-        return '/'.join(nowList)
+        return os.sep.join(nowList)
     return nowList
 
 # 计算寻路路径
@@ -264,7 +264,7 @@ def getSceneDataForMap(mapPath,mapSceneId):
     if mapPathStr == '':
         scenePathStr = str(mapSceneId)
     else:
-        scenePathStr = mapPathStr + '/' + str(mapSceneId)
+        scenePathStr = mapPathStr + os.sep + str(mapSceneId)
     scenePath = getScenePathForTrue(scenePathStr)
     scenePathStr = getMapSystemPathStrForList(scenePath)
     return CacheContorl.sceneData[scenePathStr]
@@ -287,7 +287,7 @@ def getScenePathForTrue(scenePath):
         return scenePath
     else:
         if isinstance(scenePath,str):
-            scenePath = scenePath.split('/')
+            scenePath = scenePath.split(os.sep)
         scenePath.append('0')
         return getScenePathForTrue(scenePath)
 


### PR DESCRIPTION
现在win10, python3.7.1下可以正常启动、地图间移动

- 处理目录字符串时，'/'换成os.sep（兼容windows）

- 修改loadDirNow逻辑（原先，读取同一目录下的Map和Map.json，会互相覆盖mapData中该目录的条目，导致要显示地图时抛KeyError）


